### PR TITLE
gcc/newlib: gcc/linux-musl: Fix `file` package conflicts

### DIFF
--- a/gcc/linux-musl/meta.yaml
+++ b/gcc/linux-musl/meta.yaml
@@ -44,15 +44,17 @@ build:
     - 'libexec/**/gcc'
     - 'libexec/**/lto*'
     - 'libexec/**/plugin/gengtype'
+  ignore_run_exports_from:
+    - file  # To make sure there are no run requirements from conda-forge
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - file  # Absent in the `main` channel; requires conda-forge.
     - make
     - texinfo
   host:
+    - file  # Absent in the `main` channel; requires conda-forge.
     # These are taken from the output of the configure scripts
     - gmp >=4.3.2
     - mpfr >=2.4.2

--- a/gcc/newlib/meta.yaml
+++ b/gcc/newlib/meta.yaml
@@ -23,14 +23,16 @@ build:
     - CI
     - TRAVIS
     - TOOLCHAIN_ARCH
+  ignore_run_exports_from:
+    - file  # To make sure there are no run requirements from conda-forge
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - file  # Absent in the `main` channel; requires conda-forge.
     - make
   host:
+    - file  # Absent in the `main` channel; requires conda-forge.
     # These are taken from the output of the configure scripts
     - gmp >=4.3.2
     - mpfr >=2.4.2


### PR DESCRIPTION
I thoroughly tested the `gcc/linux-musl` building, package versions etc.
Even with exactly the same versions of required packages and their
dependencies, the conflict remains as long as `file` is a `build` req.
I have no idea why. These `build` packages really should be compatible.

The `ignore_run_exports_from` ensures this package still won't require
`conda-forge` channel to be installed. Host packages influence it more
than the build ones.