### PR TITLE
Update gcc to 10.1 and turn C++ support on

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -353,18 +353,18 @@ jobs:
       - uses: hdl/conda-ci@master
 
   #25
-  gcc-newlib-sh-linux:
-    runs-on: "ubuntu-16.04"
-    needs: ["libisl-linux", "binutils-sh-linux", "gcc-nostdc-sh-linux"]
-    env:
-      PACKAGE: "gcc/newlib"
-      OS_NAME: "linux"
-      TOOLCHAIN_ARCH: "sh"
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
-      - uses: hdl/conda-ci@master
+  # gcc-newlib-sh-linux:
+  #   runs-on: "ubuntu-16.04"
+  #   needs: ["libisl-linux", "binutils-sh-linux", "gcc-nostdc-sh-linux"]
+  #   env:
+  #     PACKAGE: "gcc/newlib"
+  #     OS_NAME: "linux"
+  #     TOOLCHAIN_ARCH: "sh"
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         submodules: 'true'
+  #     - uses: hdl/conda-ci@master
 
   #26
   gcc-musl-sh-linux:

--- a/gcc/newlib/build.sh
+++ b/gcc/newlib/build.sh
@@ -135,7 +135,7 @@ $SRC_DIR/gcc/configure \
 	\
 	--target=$TARGET \
 	--with-pkgversion=$PKG_VERSION \
-	--enable-languages="c" \
+	--enable-languages="c,c++" \
 	--enable-threads=single \
 	--enable-multilib \
 	\

--- a/gcc/newlib/build.sh
+++ b/gcc/newlib/build.sh
@@ -106,7 +106,7 @@ cd build-newlib
 $SRC_DIR/newlib/configure \
 	--target=$TARGET \
 	\
-        --prefix=/ \
+	--prefix=$PREFIX \
 	\
 	--disable-newlib-supplied-syscalls \
 	\
@@ -114,7 +114,7 @@ $SRC_DIR/newlib/configure \
 	\
 
 make -j$CPU_COUNT
-make DESTDIR=$PREFIX install
+make install
 cd ..
 
 mkdir -p build-gcc
@@ -124,7 +124,7 @@ cd build-gcc
 #        --prefix=$PREFIX \
 $SRC_DIR/gcc/configure \
 	\
-        --prefix=/ \
+	--prefix=$PREFIX \
 	--program-prefix=$TARGET-newlib- \
 	\
         --with-gmp=$CONDA_PREFIX \
@@ -155,7 +155,7 @@ $SRC_DIR/gcc/configure \
 
 
 make -j$CPU_COUNT
-make DESTDIR=${PREFIX} install-strip
+make install-strip
 
 # Install aliases for the binutil tools
 for BINUTIL in $(ls $PREFIX/bin/$TARGET-* | grep /$TARGET-); do

--- a/gcc/newlib/build.sh
+++ b/gcc/newlib/build.sh
@@ -127,11 +127,11 @@ $SRC_DIR/gcc/configure \
 	--prefix=$PREFIX \
 	--program-prefix=$TARGET-newlib- \
 	\
-        --with-gmp=$CONDA_PREFIX \
-        --with-mpfr=$CONDA_PREFIX \
-        --with-mpc=$CONDA_PREFIX \
-        --with-isl=$CONDA_PREFIX \
-        --with-cloog=$CONDA_PREFIX \
+	--with-gmp=$CONDA_PREFIX \
+	--with-mpfr=$CONDA_PREFIX \
+	--with-mpc=$CONDA_PREFIX \
+	--with-isl=$CONDA_PREFIX \
+	--with-cloog=$CONDA_PREFIX \
 	\
 	--target=$TARGET \
 	--with-pkgversion=$PKG_VERSION \

--- a/gcc/newlib/meta.yaml
+++ b/gcc/newlib/meta.yaml
@@ -15,6 +15,7 @@ source:
     folder: newlib
 
 build:
+  detect_binary_files_with_prefix: False
   # number: 201803050325
   number: {{ environ.get('DATE_NUM') }}
   # string: 20180305_0325

--- a/gcc/newlib/meta.yaml
+++ b/gcc/newlib/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '9.2.0' %}
+{% set version = '10.1.0' %}
 
 package:
   name: gcc-{{ environ.get('TOOLCHAIN_ARCH') }}-elf-newlib
@@ -7,7 +7,7 @@ package:
 source:
   - url: http://ftp.gnu.org/gnu/gcc/gcc-{{ version }}/gcc-{{ version }}.tar.xz
     fn: gcc-{{ version }}.tar.gz
-    sha256: ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206
+    sha256: b6898a23844b656f1b68691c5c012036c2e694ac4b53a8918d4712ad876e7ea2
     folder: gcc
   - url: http://sourceware.org/pub/newlib/newlib-3.3.0.tar.gz
     fn: newlib-3.3.0.tar.gz

--- a/gcc/nostdc/build.sh
+++ b/gcc/nostdc/build.sh
@@ -91,13 +91,13 @@ mkdir -p $PREFIX/$TARGET/sysroot/usr/include
 
 $SRC_DIR/gcc/configure \
 	\
-        --prefix=/ \
+	--prefix=/ \
 	\
-        --with-gmp=$CONDA_PREFIX \
-        --with-mpfr=$CONDA_PREFIX \
-        --with-mpc=$CONDA_PREFIX \
-        --with-isl=$CONDA_PREFIX \
-        --with-cloog=$CONDA_PREFIX \
+	--with-gmp=$CONDA_PREFIX \
+	--with-mpfr=$CONDA_PREFIX \
+	--with-mpc=$CONDA_PREFIX \
+	--with-isl=$CONDA_PREFIX \
+	--with-cloog=$CONDA_PREFIX \
 	\
 	--target=$TARGET \
 	--with-pkgversion=$PKG_VERSION \

--- a/gcc/nostdc/meta.yaml
+++ b/gcc/nostdc/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '9.2.0' %}
+{% set version = '10.1.0' %}
 
 package:
   name: gcc-{{ environ.get('TOOLCHAIN_ARCH') }}-elf-nostdc
@@ -7,7 +7,7 @@ package:
 source:
   - url: http://ftp.gnu.org/gnu/gcc/gcc-{{ version }}/gcc-{{ version }}.tar.xz
     fn: gcc-{{ version }}.tar.gz
-    sha256: ea6ef08f121239da5695f76c9b33637a118dcf63e24164422231917fa61fb206
+    sha256: b6898a23844b656f1b68691c5c012036c2e694ac4b53a8918d4712ad876e7ea2
     folder: gcc
 
 build:


### PR DESCRIPTION
These changes update gcc to 10.1 and add C++ support for gcc with newlib.

This addresses #25.

Simply adding `c++` to `--enable-lanaguages` does not work, as libstdc++-v3 compilation fails (example in [run#3559265510](https://github.com/hdl/conda-compilers/runs/3559265510)).

<details><summary>Relevant error

</summary>

```
2021-09-09T17:50:07.1357393Z checking for EOWNERDEAD... no
2021-09-09T17:50:07.4128896Z configure: WARNING: uchar.h: present but cannot be compiled
2021-09-09T17:50:07.4131294Z configure: WARNING: uchar.h:     check for missing prerequisite headers?
2021-09-09T17:50:07.4132244Z configure: WARNING: uchar.h: see the Autoconf documentation
2021-09-09T17:50:07.4133308Z configure: WARNING: uchar.h:     section "Present But Cannot Be Compiled"
2021-09-09T17:50:07.4135065Z configure: WARNING: uchar.h: proceeding with the compiler's result
2021-09-09T17:50:07.4752788Z configure: WARNING: sys/ioctl.h: present but cannot be compiled
2021-09-09T17:50:07.4753965Z configure: WARNING: sys/ioctl.h:     check for missing prerequisite headers?
2021-09-09T17:50:07.4754907Z configure: WARNING: sys/ioctl.h: see the Autoconf documentation
2021-09-09T17:50:07.4755833Z configure: WARNING: sys/ioctl.h:     section "Present But Cannot Be Compiled"
2021-09-09T17:50:07.4757419Z configure: WARNING: sys/ioctl.h: proceeding with the compiler's result
2021-09-09T17:50:07.5768378Z configure: WARNING: sys/uio.h: present but cannot be compiled
2021-09-09T17:50:07.5769546Z configure: WARNING: sys/uio.h:     check for missing prerequisite headers?
2021-09-09T17:50:07.5770469Z configure: WARNING: sys/uio.h: see the Autoconf documentation
2021-09-09T17:50:07.5771395Z configure: WARNING: sys/uio.h:     section "Present But Cannot Be Compiled"
2021-09-09T17:50:07.5772939Z configure: WARNING: sys/uio.h: proceeding with the compiler's result
2021-09-09T17:50:07.6197657Z configure: WARNING: fenv.h: present but cannot be compiled
2021-09-09T17:50:07.6198800Z configure: WARNING: fenv.h:     check for missing prerequisite headers?
2021-09-09T17:50:07.6199751Z configure: WARNING: fenv.h: see the Autoconf documentation
2021-09-09T17:50:07.6200656Z configure: WARNING: fenv.h:     section "Present But Cannot Be Compiled"
2021-09-09T17:50:07.6202142Z configure: WARNING: fenv.h: proceeding with the compiler's result
2021-09-09T17:50:07.6947584Z configure: WARNING: stdbool.h: present but cannot be compiled
2021-09-09T17:50:07.6948809Z configure: WARNING: stdbool.h:     check for missing prerequisite headers?
2021-09-09T17:50:07.6949778Z configure: WARNING: stdbool.h: see the Autoconf documentation
2021-09-09T17:50:07.6950705Z configure: WARNING: stdbool.h:     section "Present But Cannot Be Compiled"
2021-09-09T17:50:07.6952214Z configure: WARNING: stdbool.h: proceeding with the compiler's result
2021-09-09T17:50:07.7243875Z configure: WARNING: stdalign.h: present but cannot be compiled
2021-09-09T17:50:07.7244944Z configure: WARNING: stdalign.h:     check for missing prerequisite headers?
2021-09-09T17:50:07.7245921Z configure: WARNING: stdalign.h: see the Autoconf documentation
2021-09-09T17:50:07.7246856Z configure: WARNING: stdalign.h:     section "Present But Cannot Be Compiled"
2021-09-09T17:50:07.7248348Z configure: WARNING: stdalign.h: proceeding with the compiler's result
2021-09-09T17:50:07.7541210Z configure: error: computing EOF failed
2021-09-09T17:50:07.7953876Z make[1]: *** [Makefile:11271: configure-target-libstdc++-v3] Error 1
2021-09-09T17:50:07.7960292Z make: *** [Makefile:954: all] Error 2
```
</details>

Updating `--prefix` config option helps and fixes compilation process.

<details><summary>Unfortunately it doesn't run properly.</summary>

```
$ riscv32-elf-g++ main.cpp
riscv32-elf-g++: fatal error: cannot read spec file '/home/user/conda/miniconda3/envs/gcc/lib/gcc/': Is a directory
compilation terminated.

$ riscv32-elf-gcc main.cpp
riscv32-elf-gcc: error: main.cpp: C++ compiler not installed on this system

$ riscv32-elf-newlib-g++ main.cpp
riscv32-elf-newlib-g++: fatal error: cannot read spec file '/home/user/conda/miniconda3/envs/gcc/lib/gcc/': Is a directory
compilation terminated.

$ cat main.cpp
#include <iostream>

using namespace std;

int main(){
        cout << "Hello World!" << endl;
        bool x = true;
        return x;
}
```
</details>
  
`conda-build` rewrites the internal paths to get rid of the build prefix, but then gcc  fails to locate necessary files. We can investigate that further in the next step.

Adding `build/detect_binary_files_with_prefix: False` value to _gcc/newlib/meta.yaml_ partially fixes the problem.

gcc and g++ work correctly now, but simple `strings` execution reveals, that paths from build process are still present in the binaries.
It doesn't seem to affect the gcc functionality though.

