### PR TITLE
lib/isl: Skip building due to missing sources tarball

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -30,6 +30,7 @@ jobs:
     env:
       PACKAGE: "lib/isl"
       OS_NAME: "linux"
+      SKIP: "true"  # See https://github.com/hdl/conda-compilers/issues/34
     steps:
       - uses: actions/checkout@v2
         with:
@@ -442,6 +443,7 @@ jobs:
     env:
       PACKAGE: "lib/isl"
       OS_NAME: "osx"
+      SKIP: "true"  # See https://github.com/hdl/conda-compilers/issues/34
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The official tarball server has been down for a few days. It might be a
temporary problem but let's simply skip its building to keep the CI
green. The very same libisl-0.21 package is built each time with the
only differences coming from dependencies and Conda changes.

Perhaps the official servers will go back online until a new build of
this package is needed.

Related to: #34