### PR TITLE
 Fix paths in `conda-ci` and remove `scripts` submodule

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -33,8 +33,6 @@ jobs:
       SKIP: "true"  # See https://github.com/hdl/conda-compilers/issues/34
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #2
@@ -46,8 +44,6 @@ jobs:
       TOOLCHAIN_ARCH: "or1k"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #3
@@ -60,8 +56,6 @@ jobs:
       TOOLCHAIN_ARCH: "or1k"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #4
@@ -74,8 +68,6 @@ jobs:
       TOOLCHAIN_ARCH: "or1k"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #5
@@ -88,8 +80,6 @@ jobs:
       TOOLCHAIN_ARCH: "or1k"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #6
@@ -102,8 +92,6 @@ jobs:
       TOOLCHAIN_ARCH: "or1k"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #7
@@ -115,8 +103,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #8
@@ -129,8 +115,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #9
@@ -143,8 +127,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #10
@@ -157,8 +139,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #11
@@ -171,8 +151,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #12
@@ -184,8 +162,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv64"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #13
@@ -198,8 +174,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv64"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #14
@@ -212,8 +186,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv64"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #15
@@ -226,8 +198,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv64"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #16
@@ -240,8 +210,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv64"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #17
@@ -253,8 +221,6 @@ jobs:
       TOOLCHAIN_ARCH: "lm32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #18
@@ -267,8 +233,6 @@ jobs:
       TOOLCHAIN_ARCH: "lm32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #19
@@ -281,8 +245,6 @@ jobs:
       TOOLCHAIN_ARCH: "lm32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #20
@@ -295,8 +257,6 @@ jobs:
       TOOLCHAIN_ARCH: "lm32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #21
@@ -308,8 +268,6 @@ jobs:
       TOOLCHAIN_ARCH: "ppc64le"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #22
@@ -322,8 +280,6 @@ jobs:
       TOOLCHAIN_ARCH: "ppc64le"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #23
@@ -335,8 +291,6 @@ jobs:
       TOOLCHAIN_ARCH: "sh"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #24
@@ -349,8 +303,6 @@ jobs:
       TOOLCHAIN_ARCH: "sh"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #25
@@ -363,8 +315,6 @@ jobs:
       TOOLCHAIN_ARCH: "sh"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #26
@@ -377,8 +327,6 @@ jobs:
       TOOLCHAIN_ARCH: "sh"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #27
@@ -391,8 +339,6 @@ jobs:
       TOOLCHAIN_ARCH: "or1k"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #28
@@ -405,8 +351,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #29
@@ -419,8 +363,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv64"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #30
@@ -433,8 +375,6 @@ jobs:
       TOOLCHAIN_ARCH: "sh"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #31
@@ -446,8 +386,6 @@ jobs:
       SKIP: "true"  # See https://github.com/hdl/conda-compilers/issues/34
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #32
@@ -459,8 +397,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #33
@@ -472,8 +408,6 @@ jobs:
       TOOLCHAIN_ARCH: "riscv64"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #34
@@ -485,8 +419,6 @@ jobs:
       TOOLCHAIN_ARCH: "lm32"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #35
@@ -498,8 +430,6 @@ jobs:
       TOOLCHAIN_ARCH: "ppc64le"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #36
@@ -510,8 +440,6 @@ jobs:
       OS_NAME: "linux"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #37
@@ -522,8 +450,6 @@ jobs:
       OS_NAME: "osx"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - run: brew install coreutils boost
       - uses: hdl/conda-ci@master
 
@@ -536,8 +462,6 @@ jobs:
       SKIP: "true"
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: 'true'
       - uses: hdl/conda-ci@master
 
   #39
@@ -550,8 +474,6 @@ jobs:
   #     TOOLCHAIN_ARCH: "sh"
   #   steps:
   #     - uses: actions/checkout@v2
-  #       with:
-  #         submodules: 'true'
   #     - uses: hdl/conda-ci@master
 
 
@@ -559,14 +481,20 @@ jobs:
     runs-on: "ubuntu-20.04"
     env:
       OS_NAME: "linux"
+      CI_SCRIPTS_REL_PATH: "conda-ci"
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
-          submodules: 'true'
+          repository: hdl/conda-ci
+          ref: master
+          path: ${{ env.CI_SCRIPTS_REL_PATH }}
       - uses: actions/setup-python@v1
       - uses: BSFishy/pip-action@v1
         with:
           packages: urllib3
       - run: |
-          bash .github/scripts/install.sh
-          python .github/scripts/wait-for-statuses.py
+          # Required internally by the scripts to locate other scripts.
+          export CI_SCRIPTS_PATH="$GITHUB_WORKSPACE/$CI_SCRIPTS_REL_PATH"
+          bash $CI_SCRIPTS_PATH/install.sh
+          python $CI_SCRIPTS_PATH/wait-for-statuses.py

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "conda-ci"]
-	path = .github/scripts
-	url = https://github.com/hdl/conda-ci.git
-	branch = master

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ To build a package similarly to how the packages are built in the CI it is
 recommended to pass the following optional arguments:
 * `--channels litex-hub` – to search for build dependencies in the LiteX-Hub
   channel in addition to the recipe-specific channels (from its `condarc` file),
-* `--packages conda-build=3.20.3 python=3.7` – to use the same versions of
+* `--packages python=3.7` – to use the same versions of
   packages that influence building as in the CI.
 
 After preparing, the output `DIRECTORY` will contain subdirectories:
@@ -243,7 +243,7 @@ if [ ! -v RECIPE_PATH ]; then
 fi
 
 # Prepare the RECIPE with `conda-build-prepare`
-ADDITIONAL_PACKAGES="conda-build=3.20.3 python=3.7"
+ADDITIONAL_PACKAGES="python=3.7"
 python3 -m conda_build_prepare               \
             --channels litex-hub             \
             --packages $ADDITIONAL_PACKAGES  \


### PR DESCRIPTION
The same changes as in https://github.com/hdl/conda-eda/pull/152.

Let's see if the CI builds at least a few jobs properly to make sure there are no silly mistakes.