### PR TITLE
Fix GDB packages

### DIFF
--- a/gdb/build.sh
+++ b/gdb/build.sh
@@ -40,8 +40,8 @@ cd build
  \
   --disable-shared \
   --enable-static \
-
-#  --with-system-zlib \
+  --without-python \
+  --without-python-libdir
 
 make -j$CPU_COUNT
 make install

--- a/gdb/meta.yaml
+++ b/gdb/meta.yaml
@@ -28,13 +28,11 @@ requirements:
     - gcc-{{ environ.get('TOOLCHAIN_ARCH') }}-elf-nostdc
     - make
     - pkg-config
-    - python
     - texinfo
   host:
     - expat
     - mpfr >=2.4.2
     - ncurses
-    - python
     - xz
     - zlib
   run:
@@ -43,7 +41,6 @@ requirements:
     - mpfr >=2.4.2
     - ncurses
     - zlib
-    - {{ pin_compatible('python', min_pin='x.x', max_pin='x.x') }}
 
 test:
   commands:

--- a/gdb/meta.yaml
+++ b/gdb/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - mpfr >=2.4.2
     - ncurses
     - python
+    - xz
     - zlib
   run:
     - binutils-{{ environ.get('TOOLCHAIN_ARCH') }}-elf


### PR DESCRIPTION
All the packaged GDBs fail to run because of:
```
Could not find platform independent libraries <prefix>
Could not find platform dependent libraries <exec_prefix>
Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]
Fatal Python error: initfsencoding: Unable to get the locale encoding
ModuleNotFoundError: No module named 'encodings'

Current thread 0x00007ff12ac7aec0 (most recent call first):
Aborted
```

Building without Python fixes this problem.
I will bump GDB version after fixed gdb-*-9.1 packages get uploaded.